### PR TITLE
Hide unfinished sidebar links for upload and analytics

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -16,20 +16,15 @@ import {
   SidebarHeader,
 } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
-import { 
+import {
   LayoutDashboard,
   Camera,
-  Upload,
   Database,
   TrendingUp,
-  FileText,
-  Download,
   ShoppingCart,
   Banknote,
   BarChart3,
   Map,
-  Target,
-  MessageSquare,
   Settings,
   Users,
   BookOpen,
@@ -86,7 +81,6 @@ interface ItemWithComingSoon extends Item {
 
 const dataCapture: ItemWithComingSoon[] = [
   { title: "Inventory Management", url: "/dagu", icon: Database },
-  { title: "Forecast Upload", url: "/forecast-upload", icon: Upload },
   { title: "Snap-to-Stock", url: "/snap-to-stock", icon: Camera, comingSoon: true },
 ];
 
@@ -98,16 +92,6 @@ const forecasting: Item[] = [
 const supplyPlanning: Item[] = [
   { title: "Supply Planning", url: "/supply-planning", icon: ShoppingCart },
   { title: "CDSS Budget Alignment", url: "/budget-alignment", icon: Banknote },
-];
-
-const analytics: Item[] = [
-  { title: "Facility Trends", url: "/analytics/facility", icon: BarChart3 },
-  { title: "Regional/National Trends", url: "/analytics/regional", icon: Map },
-  { title: "Forecast Accuracy", url: "/analytics/accuracy", icon: Target },
-];
-
-const aiAssistant: Item[] = [
-  { title: "AI Assistant", url: "/ai-assistant", icon: MessageSquare },
 ];
 
 const settings: Item[] = [
@@ -261,8 +245,6 @@ const AppSidebar = () => {
         {permissions.canViewOwnFacility && <Group label="Data Capture" items={dataCapture} />}
         {permissions.canGenerateForecast && <Group label="Forecasting" items={forecasting} />}
         {permissions.canViewAnalytics && <Group label="Supply Planning" items={supplyPlanning} />}
-        {permissions.canViewAnalytics && <Group label="Analytics & Reports" items={analytics} />}
-        <Group label="" items={aiAssistant} />
         {(permissions.canManageSystem || permissions.isFacilityLevel) && <Group label="Settings" items={settings} />}
         {adminItems.length > 0 && <Group label="Admin" items={adminItems} />}
         <Group label="Help & Training" items={helpTraining} />

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -110,7 +110,7 @@ export const navigationPages: Record<string, NavigationPage> = {
     description: 'Upload and manage forecast data',
     category: 'data-capture',
     breadcrumbLabel: 'Forecast Upload',
-    showInSidebar: true,
+    showInSidebar: false,
   },
 
   // Forecasting
@@ -180,7 +180,7 @@ export const navigationPages: Record<string, NavigationPage> = {
     description: 'Analyze facility-level trends and patterns',
     category: 'analytics',
     breadcrumbLabel: 'Facility Trends',
-    showInSidebar: true,
+    showInSidebar: false,
   },
   '/analytics/regional': {
     path: '/analytics/regional',
@@ -188,7 +188,7 @@ export const navigationPages: Record<string, NavigationPage> = {
     description: 'Regional and national trend analysis',
     category: 'analytics',
     breadcrumbLabel: 'Regional Trends',
-    showInSidebar: true,
+    showInSidebar: false,
   },
   '/analytics/accuracy': {
     path: '/analytics/accuracy',
@@ -196,7 +196,7 @@ export const navigationPages: Record<string, NavigationPage> = {
     description: 'Measure and analyze forecast accuracy',
     category: 'analytics',
     breadcrumbLabel: 'Forecast Accuracy',
-    showInSidebar: true,
+    showInSidebar: false,
   },
 
   // Settings


### PR DESCRIPTION
## Summary
- remove the Forecast Upload, Analytics, and AI Assistant destinations from the sidebar so only implemented routes are exposed
- update the navigation metadata to mark those unfinished pages as hidden

## Testing
- npm run lint *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cc839648832eb3137de5aae85e1a