### PR TITLE
Refactor ForecastHome to reuse shared components

### DIFF
--- a/src/components/home/KPICards.tsx
+++ b/src/components/home/KPICards.tsx
@@ -4,74 +4,99 @@ import { AlertTriangle, PackageOpen, Timer } from "lucide-react";
 import { useInventoryData } from "@/hooks/useInventoryData";
 import { useUserRole } from "@/hooks/useUserRole";
 
+import type { LucideIcon } from "lucide-react";
+
+export interface KPIItem {
+  label: string;
+  value: string | number;
+  Icon: LucideIcon;
+  color?: string;
+}
+
 interface KPIsProps {
   stockouts?: number;
   lowStock?: number;
   overstock?: number;
   nearExpiry?: number;
+  items?: KPIItem[];
+  isLoading?: boolean;
 }
 
-const num = (n?: number) => (n ?? 0).toLocaleString();
+const num = (n?: number | string) => {
+  if (typeof n === "string") {
+    return n;
+  }
 
-const KPICards: React.FC<KPIsProps> = ({ 
-  stockouts: propStockouts, 
-  lowStock: propLowStock, 
-  overstock: propOverstock, 
-  nearExpiry: propNearExpiry 
+  return (n ?? 0).toLocaleString();
+};
+
+const KPICards: React.FC<KPIsProps> = ({
+  stockouts: propStockouts,
+  lowStock: propLowStock,
+  overstock: propOverstock,
+  nearExpiry: propNearExpiry,
+  items,
+  isLoading,
 }) => {
   const { userRole } = useUserRole();
-  const { balances, loading } = useInventoryData(userRole?.facility_id);
+  const { balances, loading: inventoryLoading } = useInventoryData(userRole?.facility_id);
 
-  // Calculate real KPIs from database
+  const hasCustomItems = Boolean(items && items.length > 0);
+  const loading = isLoading ?? (hasCustomItems ? false : inventoryLoading);
+
   const realKPIs = React.useMemo(() => {
     if (!balances || balances.length === 0) {
       return { stockouts: 0, lowStock: 0, overstock: 0, nearExpiry: 0 };
     }
 
     const stockouts = balances.filter(b => b.current_stock === 0).length;
-    const lowStock = balances.filter(b => 
+    const lowStock = balances.filter(b =>
       b.current_stock > 0 && b.current_stock <= b.reorder_level
     ).length;
-    const overstock = balances.filter(b => 
+    const overstock = balances.filter(b =>
       b.current_stock > b.max_level
     ).length;
-    
-    // For near expiry, we'd need expiry date data which isn't in current schema
-    const nearExpiry = 0; // TODO: Add expiry tracking
+
+    const nearExpiry = 0;
 
     return { stockouts, lowStock, overstock, nearExpiry };
   }, [balances]);
 
-  // Use real data if available, otherwise fall back to props
-  const kpis = loading ? 
-    { stockouts: 0, lowStock: 0, overstock: 0, nearExpiry: 0 } :
-    {
-      stockouts: propStockouts ?? realKPIs.stockouts,
-      lowStock: propLowStock ?? realKPIs.lowStock,
-      overstock: propOverstock ?? realKPIs.overstock,
-      nearExpiry: propNearExpiry ?? realKPIs.nearExpiry,
-    };
+  const derivedItems: KPIItem[] = React.useMemo(() => {
+    if (hasCustomItems && items) {
+      return items;
+    }
 
-  const items = [
-    { label: "Stockouts", value: kpis.stockouts, Icon: AlertTriangle, color: "text-red-600" },
-    { label: "Low stock", value: kpis.lowStock, Icon: PackageOpen, color: "text-amber-600" },
-    { label: "Overstock", value: kpis.overstock, Icon: PackageOpen, color: "text-blue-600" },
-    { label: "Near-expiry", value: kpis.nearExpiry, Icon: Timer, color: "text-orange-600" },
-  ];
+    const kpis = loading
+      ? { stockouts: 0, lowStock: 0, overstock: 0, nearExpiry: 0 }
+      : {
+          stockouts: propStockouts ?? realKPIs.stockouts,
+          lowStock: propLowStock ?? realKPIs.lowStock,
+          overstock: propOverstock ?? realKPIs.overstock,
+          nearExpiry: propNearExpiry ?? realKPIs.nearExpiry,
+        };
+
+    return [
+      { label: "Stockouts", value: kpis.stockouts, Icon: AlertTriangle, color: "text-red-600" },
+      { label: "Low stock", value: kpis.lowStock, Icon: PackageOpen, color: "text-amber-600" },
+      { label: "Overstock", value: kpis.overstock, Icon: PackageOpen, color: "text-blue-600" },
+      { label: "Near-expiry", value: kpis.nearExpiry, Icon: Timer, color: "text-orange-600" },
+    ];
+  }, [hasCustomItems, items, loading, propStockouts, propLowStock, propOverstock, propNearExpiry, realKPIs]);
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-      {items.map(({ label, value, Icon, color }) => (
+      {derivedItems.map(({ label, value, Icon, color }) => (
         <Card key={label} className="surface">
           <CardContent className="py-4">
             <div className="flex items-center justify-between">
               <div>
                 <div className="text-sm text-muted-foreground">{label}</div>
-                <div className={`text-2xl font-semibold ${loading ? 'text-muted-foreground' : color}`}>
+                <div className={`text-2xl font-semibold ${loading ? "text-muted-foreground" : color ?? ""}`}>
                   {loading ? "..." : num(value)}
                 </div>
               </div>
-              <Icon className={`h-5 w-5 ${loading ? 'text-muted-foreground' : color}`} />
+              <Icon className={`h-5 w-5 ${loading ? "text-muted-foreground" : color ?? ""}`} />
             </div>
           </CardContent>
         </Card>

--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -2,24 +2,47 @@ import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
-import { 
-  Package, 
-  TrendingUp, 
-  FileText, 
+import {
+  Package,
+  TrendingUp,
+  FileText,
   BarChart3,
   AlertTriangle,
   Plus,
-  Search,
-  Calendar
+  Search
 } from "lucide-react";
 import { useInventoryData } from "@/hooks/useInventoryData";
 import { useUserRole } from "@/hooks/useUserRole";
 
-interface Props {
-  onAnnounce?: () => void;
+import type { LucideIcon } from "lucide-react";
+
+type ButtonVariant = "default" | "secondary" | "outline" | "destructive" | "ghost" | "link";
+
+interface ActionConfig {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  color?: string;
+  stats?: string;
+  path?: string;
+  onClick?: () => void;
 }
 
-const QuickActions: React.FC<Props> = ({ onAnnounce }) => {
+interface QuickTaskAction {
+  title: string;
+  icon: LucideIcon;
+  variant?: ButtonVariant;
+  path?: string;
+  onClick?: () => void;
+}
+
+interface Props {
+  onAnnounce?: () => void;
+  actions?: ActionConfig[];
+  quickTasks?: QuickTaskAction[];
+}
+
+const QuickActions: React.FC<Props> = ({ onAnnounce, actions, quickTasks }) => {
   const navigate = useNavigate();
   const { userRole } = useUserRole();
   const { balances, loading: inventoryLoading } = useInventoryData(userRole?.facility_id);
@@ -40,7 +63,7 @@ const QuickActions: React.FC<Props> = ({ onAnnounce }) => {
     return { lowStock, stockouts, goodStock };
   }, [balances]);
 
-  const actions = [
+  const defaultActions: ActionConfig[] = React.useMemo(() => [
     {
       title: "Inventory Management",
       description: "Check stock levels and manage inventory",
@@ -73,89 +96,118 @@ const QuickActions: React.FC<Props> = ({ onAnnounce }) => {
       color: "bg-orange-500/10 text-orange-600",
       stats: "CDSS budget optimization"
     }
-  ];
+  ], [inventoryStats.lowStock, inventoryStats.stockouts, inventoryLoading]);
 
-  const quickTaskActions = [
+  const defaultQuickTasks: QuickTaskAction[] = React.useMemo(() => [
     {
       title: "New Request",
       icon: Plus,
       path: "/requests/new",
-      variant: "default" as const
+      variant: "default"
     },
     {
       title: "Stock Search",
       icon: Search,
       path: "/dagu",
-      variant: "outline" as const
+      variant: "outline"
     },
     {
       title: "Reports",
       icon: BarChart3,
       path: "/forecast-analysis",
-      variant: "outline" as const
+      variant: "outline"
     }
-  ];
+  ], []);
+
+  const resolvedActions = actions && actions.length > 0 ? actions : defaultActions;
+  const resolvedQuickTasks = quickTasks && quickTasks.length > 0 ? quickTasks : defaultQuickTasks;
+
+  const handleActionClick = (action: ActionConfig) => {
+    if (action.onClick) {
+      action.onClick();
+      return;
+    }
+
+    if (action.path) {
+      navigate(action.path);
+    }
+  };
+
+  const handleQuickTaskClick = (task: QuickTaskAction) => {
+    if (task.onClick) {
+      task.onClick();
+      return;
+    }
+
+    if (task.path) {
+      navigate(task.path);
+    }
+  };
 
   return (
     <div className="space-y-6">
-      {/* Main Action Cards */}
-      <Card className="surface">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Package className="h-5 w-5" />
-            Quick Actions
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {actions.map((action) => (
-              <div
-                key={action.title}
-                className="p-4 border rounded-lg hover:bg-accent/50 cursor-pointer transition-colors"
-                onClick={() => navigate(action.path)}
-              >
-                <div className="flex items-start gap-3">
-                  <div className={`p-2 rounded-lg ${action.color}`}>
-                    <action.icon className="h-5 w-5" />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <h3 className="font-medium text-sm">{action.title}</h3>
-                    <p className="text-xs text-muted-foreground mb-2">
-                      {action.description}
-                    </p>
-                    <p className="text-xs text-muted-foreground font-medium">
-                      {action.stats}
-                    </p>
+      {resolvedActions.length > 0 && (
+        <Card className="surface">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Package className="h-5 w-5" />
+              Quick Actions
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {resolvedActions.map((action) => (
+                <div
+                  key={action.title}
+                  className="p-4 border rounded-lg hover:bg-accent/50 cursor-pointer transition-colors"
+                  onClick={() => handleActionClick(action)}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className={`p-2 rounded-lg ${action.color ?? "bg-muted"}`}>
+                      <action.icon className="h-5 w-5" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="font-medium text-sm">{action.title}</h3>
+                      <p className="text-xs text-muted-foreground mb-2">
+                        {action.description}
+                      </p>
+                      {action.stats && (
+                        <p className="text-xs text-muted-foreground font-medium">
+                          {action.stats}
+                        </p>
+                      )}
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
-      {/* Quick Task Buttons */}
-      <Card className="surface">
-        <CardHeader>
-          <CardTitle className="text-base">Quick Tasks</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap gap-2">
-            {quickTaskActions.map((action) => (
-              <Button
-                key={action.title}
-                variant={action.variant}
-                size="sm"
-                onClick={() => navigate(action.path)}
-                className="flex items-center gap-2"
-              >
-                <action.icon className="h-4 w-4" />
-                {action.title}
-              </Button>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      {resolvedQuickTasks.length > 0 && (
+        <Card className="surface">
+          <CardHeader>
+            <CardTitle className="text-base">Quick Tasks</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2">
+              {resolvedQuickTasks.map((action) => (
+                <Button
+                  key={action.title}
+                  variant={action.variant}
+                  size="sm"
+                  onClick={() => handleQuickTaskClick(action)}
+                  className="flex items-center gap-2"
+                >
+                  <action.icon className="h-4 w-4" />
+                  {action.title}
+                </Button>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Critical Alerts - if any stockouts */}
       {inventoryStats.stockouts > 0 && (
@@ -192,3 +244,4 @@ const QuickActions: React.FC<Props> = ({ onAnnounce }) => {
 };
 
 export default QuickActions;
+export type { ActionConfig, QuickTaskAction };


### PR DESCRIPTION
## Summary
- extend the shared KPI cards and quick actions components so they can be configured with custom items and handlers
- refactor the Forecast Home page to consume the shared KPI, quick actions, and stock exchange components and wire callbacks via props instead of inline alerts
- surface stock exchange activity and richer quick tasks while keeping the forecasting layout intact

## Testing
- npm run lint *(fails: existing lint violations throughout unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cc9cc570832e8e66d284ec502089