### PR TITLE
Refactor user data hooks to use react-query caching

### DIFF
--- a/src/components/auth/UserProfileBadge.tsx
+++ b/src/components/auth/UserProfileBadge.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useAuth } from '@/context/AuthContext';
-import { useUserRole } from '@/hooks/useUserRole';
-import { useUserFacility } from '@/hooks/useUserFacility';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -9,12 +8,16 @@ import { User, MapPin, Shield } from 'lucide-react';
 
 export const UserProfileBadge: React.FC = () => {
   const { user } = useAuth();
-  const { userRole, loading: roleLoading } = useUserRole();
-  const facilityInfo = useUserFacility();
+  const {
+    loading,
+    roleDetails,
+    facilityName,
+    locationDisplay,
+    facilityRole,
+    facilityAdminLevel,
+  } = useCurrentUser();
 
   if (!user) return null;
-
-  const loading = roleLoading || facilityInfo.loading;
 
   if (loading) {
     return (
@@ -48,27 +51,27 @@ export const UserProfileBadge: React.FC = () => {
           </p>
         </div>
         
-        {userRole && (
+        {facilityRole && (
           <div className="flex items-center gap-2 mb-1">
             <Shield className="h-3 w-3 text-muted-foreground" />
             <Badge variant="secondary" className="text-xs">
-              {userRole.role}
-              {userRole.admin_level && ` (${userRole.admin_level})`}
+              {facilityRole}
+              {facilityAdminLevel && ` (${facilityAdminLevel})`}
             </Badge>
           </div>
         )}
-        
-        {facilityInfo?.facilityName && (
+
+        {facilityName && (
           <div className="flex items-center gap-2">
             <MapPin className="h-3 w-3 text-muted-foreground" />
             <p className="text-xs text-muted-foreground truncate">
-              {facilityInfo.facilityName}
-              {facilityInfo.locationDisplay && ` - ${facilityInfo.locationDisplay}`}
+              {facilityName}
+              {locationDisplay && ` - ${locationDisplay}`}
             </p>
           </div>
         )}
-        
-        {!facilityInfo?.facilityName && !userRole?.role && (
+
+        {!facilityName && !roleDetails?.role && (
           <p className="text-xs text-amber-600">
             Role assignment pending
           </p>

--- a/src/components/dashboard/DashboardWidgets.tsx
+++ b/src/components/dashboard/DashboardWidgets.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
-import { useUserRole } from "@/hooks/useUserRole";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface DashboardStats {
   dataSubmissionRate: number;
@@ -36,7 +36,7 @@ interface CommodityStatus {
 }
 
 const DashboardWidgets: React.FC = () => {
-  const { userRole } = useUserRole();
+  const { userRole } = useCurrentUser();
   const [stats, setStats] = useState<DashboardStats>({
     dataSubmissionRate: 0,
     pendingFacilities: 0,

--- a/src/components/dashboard/FacilityKeyMetrics.tsx
+++ b/src/components/dashboard/FacilityKeyMetrics.tsx
@@ -12,7 +12,7 @@ import {
   MapPin
 } from "lucide-react";
 import { useInventoryData } from "@/hooks/useInventoryData";
-import { useUserRole } from "@/hooks/useUserRole";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface MetricCardProps {
   title: string;
@@ -73,8 +73,8 @@ const MetricCard: React.FC<MetricCardProps> = ({ title, value, status, descripti
 };
 
 export const FacilityKeyMetrics: React.FC = () => {
-  const { userRole } = useUserRole();
-  const { balances, loading } = useInventoryData(userRole?.facility_id);
+  const { facilityId } = useCurrentUser();
+  const { balances, loading } = useInventoryData(facilityId ?? undefined);
 
   // Calculate metrics
   const metrics = React.useMemo(() => {

--- a/src/components/dashboard/TodayTriagePanel.tsx
+++ b/src/components/dashboard/TodayTriagePanel.tsx
@@ -13,7 +13,7 @@ import {
   Calendar
 } from "lucide-react";
 import { useInventoryData } from "@/hooks/useInventoryData";
-import { useUserRole } from "@/hooks/useUserRole";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface TriageItem {
   id: string;
@@ -28,8 +28,8 @@ interface TriageItem {
 
 export const TodayTriagePanel: React.FC = () => {
   const navigate = useNavigate();
-  const { userRole } = useUserRole();
-  const { balances, loading } = useInventoryData(userRole?.facility_id);
+  const { facilityId } = useCurrentUser();
+  const { balances, loading } = useInventoryData(facilityId ?? undefined);
 
   // Calculate real-time counts
   const triageStats = React.useMemo(() => {

--- a/src/components/home/ForecastQuickActions.tsx
+++ b/src/components/home/ForecastQuickActions.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useNavigate } from "react-router-dom";
-import { useUserRole } from "@/hooks/useUserRole";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useOutstandingRequests } from "@/hooks/useOutstandingRequests";
 import OutstandingRequestsModal from "./OutstandingRequestsModal";
 import {
@@ -33,19 +33,19 @@ interface QuickTask {
 
 const CriticalQuickActions: React.FC = () => {
   const navigate = useNavigate();
-  const { userRole } = useUserRole();
+  const { userRole, adminLevel } = useCurrentUser();
   const { requests } = useOutstandingRequests();
   const [showOutstandingModal, setShowOutstandingModal] = useState(false);
 
   const getTasksByRole = (): QuickTask[] => {
-    const role = userRole?.role;
-    const adminLevel = userRole?.admin_level;
-    
+    const role = userRole;
+    const level = adminLevel;
+
     // Debug logging to see current user role
-    console.log('Current user role:', role, 'admin level:', adminLevel);
+    console.log('Current user role:', role, 'admin level:', level);
 
     // Facility Logistic Officer tasks - reordered as requested
-    if (role === "viewer" && adminLevel === "logistic_officer") {
+    if (role === "viewer" && level === "logistic_officer") {
       return [
         {
           title: "Receive Stock",
@@ -221,16 +221,13 @@ const CriticalQuickActions: React.FC = () => {
   };
 
   const getRoleTitle = () => {
-    const role = userRole?.role;
-    const adminLevel = userRole?.admin_level;
-    
-    if (role === "viewer" && adminLevel === "logistic_officer") {
+    if (userRole === "viewer" && adminLevel === "logistic_officer") {
       return "Logistic Officer Daily Tasks";
     }
-    if (role === "analyst") {
+    if (userRole === "analyst") {
       return "Regional Manager Tasks";
     }
-    if (role === "admin") {
+    if (userRole === "admin") {
       return "National Administrator Tasks";
     }
     return "Quick Tasks";

--- a/src/components/home/KPICards.tsx
+++ b/src/components/home/KPICards.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { AlertTriangle, PackageOpen, Timer } from "lucide-react";
 import { useInventoryData } from "@/hooks/useInventoryData";
-import { useUserRole } from "@/hooks/useUserRole";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 import type { LucideIcon } from "lucide-react";
 
@@ -38,8 +38,8 @@ const KPICards: React.FC<KPIsProps> = ({
   items,
   isLoading,
 }) => {
-  const { userRole } = useUserRole();
-  const { balances, loading: inventoryLoading } = useInventoryData(userRole?.facility_id);
+  const { facilityId } = useCurrentUser();
+  const { balances, loading: inventoryLoading } = useInventoryData(facilityId ?? undefined);
 
   const hasCustomItems = Boolean(items && items.length > 0);
   const loading = isLoading ?? (hasCustomItems ? false : inventoryLoading);

--- a/src/components/home/QuickActions.tsx
+++ b/src/components/home/QuickActions.tsx
@@ -12,7 +12,7 @@ import {
   Search
 } from "lucide-react";
 import { useInventoryData } from "@/hooks/useInventoryData";
-import { useUserRole } from "@/hooks/useUserRole";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 import type { LucideIcon } from "lucide-react";
 
@@ -37,8 +37,8 @@ interface Props {
 
 const QuickActions: React.FC<Props> = ({ onAnnounce, actions }) => {
   const navigate = useNavigate();
-  const { userRole } = useUserRole();
-  const { balances, loading: inventoryLoading } = useInventoryData(userRole?.facility_id);
+  const { facilityId } = useCurrentUser();
+  const { balances, loading: inventoryLoading } = useInventoryData(facilityId ?? undefined);
 
   // Calculate inventory stats from real data
   const inventoryStats = React.useMemo(() => {

--- a/src/components/home/StockExchangeBoard.tsx
+++ b/src/components/home/StockExchangeBoard.tsx
@@ -4,7 +4,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { supabase } from "@/integrations/supabase/client";
-import { useUserRole } from "@/hooks/useUserRole";
 
 export type StockPost = {
   id: string;
@@ -25,7 +24,6 @@ interface Props {
 }
 
 const StockExchangeBoard: React.FC<Props> = ({ posts = [], onCreate }) => {
-  const { userRole } = useUserRole();
   const [realExcess, setRealExcess] = useState<StockPost[]>([]);
   const [realNeeds, setRealNeeds] = useState<StockPost[]>([]);
   const [loading, setLoading] = useState(true);

--- a/src/components/inventory/SimpleInventoryManager.tsx
+++ b/src/components/inventory/SimpleInventoryManager.tsx
@@ -9,7 +9,7 @@ import { IssuingModule } from "./IssuingModule";
 import { StockOverview } from "./StockOverview";
 import { AdjustmentModule } from "./AdjustmentModule";
 import { TodayQuickStats } from "./TodayQuickStats";
-import { useUserRole } from "@/hooks/useUserRole";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import GuidedForecastingFlow from "@/components/forecast/GuidedForecastingFlow";
 
 
@@ -20,8 +20,8 @@ export const SimpleInventoryManager: React.FC = () => {
   const [showForecastFlow, setShowForecastFlow] = useState(false);
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { userRole } = useUserRole();
-  const facilityId = userRole?.facility_id || 1; // Get from user context or fallback
+  const { facilityId: resolvedFacilityId } = useCurrentUser();
+  const facilityId = resolvedFacilityId || 1; // Get from user context or fallback
 
   // Handle tab parameter from URL
   useEffect(() => {

--- a/src/components/workflow/FacilityWorkflow.tsx
+++ b/src/components/workflow/FacilityWorkflow.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Calendar, Package, TrendingUp, FileText, Truck, AlertTriangle } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
-import { useUserRole } from "@/hooks/useUserRole";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 interface UpcomingTask {
   title: string;
@@ -27,7 +27,7 @@ const getPriorityColor = (priority: "high" | "medium" | "low") => {
 };
 
 export const FacilityWorkflow: React.FC = () => {
-  const { userRole } = useUserRole();
+  const { facilityId } = useCurrentUser();
   const [upcomingTasks, setUpcomingTasks] = useState<UpcomingTask[]>([]);
   const [workflowSteps, setWorkflowSteps] = useState([
     {
@@ -78,7 +78,7 @@ export const FacilityWorkflow: React.FC = () => {
 
   useEffect(() => {
     const fetchTasks = async () => {
-      if (!userRole?.facility_id) return;
+      if (!facilityId) return;
 
       try {
         // Get real data about pending tasks
@@ -92,28 +92,28 @@ export const FacilityWorkflow: React.FC = () => {
           supabase
             .from('inventory_balances')
             .select('id')
-            .eq('facility_id', userRole.facility_id)
+            .eq('facility_id', facilityId)
             .eq('current_stock', 0),
           
           // Low stock items  
           supabase
             .from('inventory_balances')
             .select('current_stock, reorder_level')
-            .eq('facility_id', userRole.facility_id)
+            .eq('facility_id', facilityId)
             .gt('current_stock', 0),
           
           // Recent transactions
           supabase
             .from('inventory_transactions')
             .select('id')
-            .eq('facility_id', userRole.facility_id)
+            .eq('facility_id', facilityId)
             .gte('transaction_date', new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]),
           
           // Near expiry (this would need product expiry data)
           supabase
             .from('inventory_transactions')
             .select('id')
-            .eq('facility_id', userRole.facility_id)
+            .eq('facility_id', facilityId)
             .lt('expiry_date', new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0])
         ]);
 
@@ -174,7 +174,7 @@ export const FacilityWorkflow: React.FC = () => {
     };
 
     fetchTasks();
-  }, [userRole?.facility_id]);
+  }, [facilityId]);
 
   return (
     <div className="space-y-6">

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,6 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/context/AuthContext';
-import { useUserRole } from '@/hooks/useUserRole';
-import { useUserFacility } from '@/hooks/useUserFacility';
+import {
+  createUserRoleQueryOptions,
+  UserRole,
+} from '@/hooks/useUserRole';
+import {
+  createUserFacilityQueryOptions,
+  defaultFacilityInfo,
+  UserFacilityInfo,
+} from '@/hooks/useUserFacility';
 
 /**
  * Comprehensive hook for getting current user information
@@ -8,43 +16,60 @@ import { useUserFacility } from '@/hooks/useUserFacility';
  */
 export const useCurrentUser = () => {
   const { user, loading: authLoading } = useAuth();
-  const { userRole, loading: roleLoading } = useUserRole();
-  const facilityInfo = useUserFacility();
+
+  const roleQuery = useQuery<UserRole | null, Error>({
+    ...createUserRoleQueryOptions(user?.id),
+    enabled: !!user?.id,
+  });
+
+  const resolvedRole = roleQuery.data ?? null;
+  const roleLoading = roleQuery.isPending || roleQuery.isFetching;
+
+  const facilityQuery = useQuery<UserFacilityInfo, Error>({
+    ...createUserFacilityQueryOptions(user?.id, resolvedRole),
+    enabled: !!user?.id && !roleQuery.isPending && !roleQuery.isError,
+  });
+
+  const facilityInfo = facilityQuery.data ?? defaultFacilityInfo;
+  const facilityLoading = facilityQuery.isPending || facilityQuery.isFetching;
 
   return {
     // Authentication data
     user,
     isAuthenticated: !!user,
-    
+
     // Role data
-    userRole: userRole?.role,
-    adminLevel: userRole?.admin_level,
-    facilityId: userRole?.facility_id,
-    woredaId: userRole?.woreda_id,
-    zoneId: userRole?.zone_id,
-    regionId: userRole?.region_id,
-    
+    userRole: resolvedRole?.role,
+    adminLevel: resolvedRole?.admin_level,
+    facilityId: resolvedRole?.facility_id,
+    woredaId: resolvedRole?.woreda_id,
+    zoneId: resolvedRole?.zone_id,
+    regionId: resolvedRole?.region_id,
+
     // Facility data
     facilityName: facilityInfo.facilityName,
     facilityType: facilityInfo.facilityType,
     locationDisplay: facilityInfo.locationDisplay,
-    
+
     // Loading states
-    loading: authLoading || roleLoading || facilityInfo.loading,
-    
+    loading: authLoading || (!!user?.id && (roleLoading || facilityLoading)),
+
     // Error states
-    error: facilityInfo.error,
-    
+    error:
+      roleQuery.error?.message ??
+      facilityQuery.error?.message ??
+      facilityInfo.error,
+
     // Helper functions
-    isAdmin: () => userRole?.role === 'admin',
-    isAnalyst: () => userRole?.role === 'analyst',
-    isViewer: () => userRole?.role === 'viewer',
-    
+    isAdmin: () => resolvedRole?.role === 'admin',
+    isAnalyst: () => resolvedRole?.role === 'analyst',
+    isViewer: () => resolvedRole?.role === 'viewer',
+
     // Get user ID for forms
     getUserId: () => user?.id,
-    
+
     // Get facility ID for facility-specific forms
-    getFacilityId: () => userRole?.facility_id || null,
+    getFacilityId: () => resolvedRole?.facility_id ?? null,
   };
 };
 

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -33,22 +33,30 @@ export const useCurrentUser = () => {
   const facilityInfo = facilityQuery.data ?? defaultFacilityInfo;
   const facilityLoading = facilityQuery.isPending || facilityQuery.isFetching;
 
+  const roleDetails = resolvedRole;
+  const facilityRole = facilityInfo.role ?? roleDetails?.role ?? null;
+  const facilityAdminLevel = facilityInfo.adminLevel ?? roleDetails?.admin_level ?? null;
+
   return {
     // Authentication data
     user,
     isAuthenticated: !!user,
 
     // Role data
-    userRole: resolvedRole?.role,
-    adminLevel: resolvedRole?.admin_level,
-    facilityId: resolvedRole?.facility_id,
-    woredaId: resolvedRole?.woreda_id,
-    zoneId: resolvedRole?.zone_id,
-    regionId: resolvedRole?.region_id,
+    roleDetails,
+    userRole: roleDetails?.role ?? null,
+    adminLevel: roleDetails?.admin_level ?? null,
+    facilityId: roleDetails?.facility_id ?? null,
+    woredaId: roleDetails?.woreda_id ?? null,
+    zoneId: roleDetails?.zone_id ?? null,
+    regionId: roleDetails?.region_id ?? null,
 
     // Facility data
+    facilityInfo,
     facilityName: facilityInfo.facilityName,
     facilityType: facilityInfo.facilityType,
+    facilityRole,
+    facilityAdminLevel,
     locationDisplay: facilityInfo.locationDisplay,
 
     // Loading states
@@ -61,15 +69,15 @@ export const useCurrentUser = () => {
       facilityInfo.error,
 
     // Helper functions
-    isAdmin: () => resolvedRole?.role === 'admin',
-    isAnalyst: () => resolvedRole?.role === 'analyst',
-    isViewer: () => resolvedRole?.role === 'viewer',
+    isAdmin: () => roleDetails?.role === 'admin',
+    isAnalyst: () => roleDetails?.role === 'analyst',
+    isViewer: () => roleDetails?.role === 'viewer',
 
     // Get user ID for forms
     getUserId: () => user?.id,
 
     // Get facility ID for facility-specific forms
-    getFacilityId: () => resolvedRole?.facility_id ?? null,
+    getFacilityId: () => roleDetails?.facility_id ?? null,
   };
 };
 

--- a/src/hooks/useUserFacility.ts
+++ b/src/hooks/useUserFacility.ts
@@ -1,25 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/context/AuthContext';
-
-interface UserFacilityInfo {
-  facilityName: string | null;
-  facilityType: string | null;
-  role: string | null;
-  adminLevel: string | null;
-  locationDisplay: string | null;
-  loading: boolean;
-  error: string | null;
-}
-
-interface UserRole {
-  role: string | null;
-  admin_level: string | null;
-  facility_id: number | null;
-  woreda_id: number | null;
-  zone_id: number | null;
-  region_id: number | null;
-}
+import { useUserRole, UserRole } from '@/hooks/useUserRole';
 
 interface FacilityHierarchy {
   facility_name: string;
@@ -58,307 +40,359 @@ interface RegionLocation {
 
 type AdministrativeLocation = WoredaLocation | ZoneLocation | RegionLocation | null;
 
+type LocationSource =
+  | AdministrativeLocation
+  | FacilityHierarchy['woreda']
+  | null
+  | undefined;
+
 interface PendingRequest {
   requested_role: string | null;
   admin_level: string | null;
   status: string;
 }
 
-type LocationSource = AdministrativeLocation | FacilityHierarchy['woreda'] | null | undefined;
+export interface UserFacilityInfo {
+  facilityName: string | null;
+  facilityType: string | null;
+  role: string | null;
+  adminLevel: string | null;
+  locationDisplay: string | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export const defaultFacilityInfo: UserFacilityInfo = {
+  facilityName: null,
+  facilityType: null,
+  role: null,
+  adminLevel: null,
+  locationDisplay: null,
+  loading: false,
+  error: null,
+};
+
+const collectLocationParts = (location: LocationSource) => {
+  if (!location) return [] as string[];
+
+  const parts: string[] = [];
+
+  if ('woreda_name' in location && location.woreda_name) {
+    parts.push(location.woreda_name);
+  }
+
+  if ('zone_name' in location && location.zone_name) {
+    parts.push(location.zone_name);
+  }
+
+  if ('region_name' in location && location.region_name) {
+    parts.push(location.region_name);
+  }
+
+  if ('zone' in location && location.zone?.zone_name) {
+    parts.push(location.zone.zone_name);
+  }
+
+  if ('zone' in location && location.zone?.region?.region_name) {
+    parts.push(location.zone.region.region_name);
+  }
+
+  if ('region' in location && location.region?.region_name) {
+    parts.push(location.region.region_name);
+  }
+
+  return Array.from(new Set(parts));
+};
+
+const fetchFacilityWithHierarchy = async (
+  facilityId: number,
+): Promise<FacilityHierarchy | null> => {
+  const { data, error } = await supabase
+    .from('facility')
+    .select(
+      `
+        facility_name,
+        facility_type,
+        woreda!facility_woreda_id_fkey (
+          woreda_name,
+          zone!woreda_zone_id_fkey (
+            zone_name,
+            region!zone_region_id_fkey (
+              region_name
+            )
+          )
+        )
+      `,
+    )
+    .eq('facility_id', facilityId)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return (data as FacilityHierarchy | null) ?? null;
+};
+
+const fetchAdministrativeLocation = async (
+  role: UserRole,
+): Promise<AdministrativeLocation> => {
+  if (role.woreda_id) {
+    const { data, error } = await supabase
+      .from('woreda')
+      .select(
+        `
+          woreda_name,
+          zone!woreda_zone_id_fkey (
+            zone_name,
+            region!zone_region_id_fkey (
+              region_name
+            )
+          )
+        `,
+      )
+      .eq('woreda_id', role.woreda_id)
+      .maybeSingle();
+
+    if (error) throw error;
+    return data as WoredaLocation | null;
+  }
+
+  if (role.zone_id) {
+    const { data, error } = await supabase
+      .from('zone')
+      .select(
+        `
+          zone_name,
+          region!zone_region_id_fkey (
+            region_name
+          )
+        `,
+      )
+      .eq('zone_id', role.zone_id)
+      .maybeSingle();
+
+    if (error) throw error;
+    return data as ZoneLocation | null;
+  }
+
+  if (role.region_id) {
+    const { data, error } = await supabase
+      .from('region')
+      .select('region_name')
+      .eq('region_id', role.region_id)
+      .maybeSingle();
+
+    if (error) throw error;
+    return data as RegionLocation | null;
+  }
+
+  return null;
+};
+
+const buildLocationDisplay = ({
+  facility,
+  location,
+  adminLevel,
+  role,
+}: {
+  facility?: FacilityHierarchy | null;
+  location?: AdministrativeLocation;
+  adminLevel: string | null;
+  role: string | null;
+}) => {
+  if (facility) {
+    const locationParts = collectLocationParts(facility.woreda);
+    let display = `${facility.facility_name}${facility.facility_type ? ` (${facility.facility_type})` : ''}`;
+    if (locationParts.length) {
+      display += ` – ${locationParts.join(', ')}`;
+    }
+    return display;
+  }
+
+  const locationParts = collectLocationParts(location);
+  if (locationParts.length) {
+    return `${locationParts.join(', ')}${adminLevel ? ` – ${adminLevel} Level` : ''}`;
+  }
+
+  return role ? `${role} Dashboard` : 'National Overview';
+};
+
+const buildPendingOrNoRoleInfo = async (userId: string): Promise<UserFacilityInfo> => {
+  const [
+    { data: pendingRequestsData, error: pendingError },
+    { data: profileData, error: profileError },
+  ] = await Promise.all([
+    supabase
+      .from('user_role_requests')
+      .select('requested_role, admin_level, status')
+      .eq('user_id', userId)
+      .eq('status', 'pending')
+      .limit(1),
+    supabase
+      .from('profiles')
+      .select('preferred_facility_id')
+      .eq('user_id', userId)
+      .maybeSingle(),
+  ]);
+
+  if (pendingError) throw pendingError;
+  if (profileError) throw profileError;
+
+  const pendingRequests = (pendingRequestsData as PendingRequest[] | null) || [];
+  const preferredFacilityId = profileData?.preferred_facility_id as number | null | undefined;
+
+  if (preferredFacilityId) {
+    const facility = await fetchFacilityWithHierarchy(preferredFacilityId);
+    const locationDisplay = facility
+      ? buildLocationDisplay({
+          facility,
+          adminLevel: pendingRequests[0]?.admin_level ?? null,
+          role: pendingRequests[0]?.requested_role ?? null,
+        })
+      : 'Preferred Facility';
+
+    return {
+      facilityName: facility?.facility_name ?? null,
+      facilityType: facility?.facility_type ?? null,
+      role: pendingRequests.length ? 'Pending Approval' : 'No Role Assigned',
+      adminLevel: pendingRequests[0]?.admin_level ?? null,
+      locationDisplay: pendingRequests.length
+        ? `${locationDisplay} – awaiting approval`
+        : locationDisplay,
+      loading: false,
+      error: null,
+    };
+  }
+
+  if (pendingRequests.length > 0) {
+    return {
+      facilityName: null,
+      facilityType: null,
+      role: 'Pending Approval',
+      adminLevel: pendingRequests[0].admin_level,
+      locationDisplay: 'Role request pending approval',
+      loading: false,
+      error: null,
+    };
+  }
+
+  return {
+    facilityName: null,
+    facilityType: null,
+    role: 'No Role Assigned',
+    adminLevel: null,
+    locationDisplay: 'Please contact administrator',
+    loading: false,
+    error: null,
+  };
+};
+
+const buildAssignedRoleInfo = async (
+  primaryRole: UserRole,
+): Promise<UserFacilityInfo> => {
+  const facilityPromise: Promise<FacilityHierarchy | null> = primaryRole.facility_id
+    ? fetchFacilityWithHierarchy(primaryRole.facility_id)
+    : Promise.resolve<FacilityHierarchy | null>(null);
+
+  const locationPromise: Promise<AdministrativeLocation> = primaryRole.facility_id
+    ? Promise.resolve<AdministrativeLocation>(null)
+    : fetchAdministrativeLocation(primaryRole);
+
+  const [facility, location] = await Promise.all([facilityPromise, locationPromise]);
+
+  const locationDisplay = buildLocationDisplay({
+    facility,
+    location,
+    adminLevel: primaryRole.admin_level ?? null,
+    role: primaryRole.role ?? null,
+  });
+
+  return {
+    facilityName: facility?.facility_name ?? null,
+    facilityType: facility?.facility_type ?? null,
+    role: primaryRole.role ?? null,
+    adminLevel: primaryRole.admin_level ?? null,
+    locationDisplay,
+    loading: false,
+    error: null,
+  };
+};
+
+export const buildUserRoleSignature = (role: UserRole | null | undefined) => {
+  if (!role) {
+    return 'no-role';
+  }
+
+  return [
+    role.role ?? 'unknown-role',
+    role.admin_level ?? 'unknown-level',
+    role.facility_id ?? 'no-facility',
+    role.woreda_id ?? 'no-woreda',
+    role.zone_id ?? 'no-zone',
+    role.region_id ?? 'no-region',
+  ].join('|');
+};
+
+export const userFacilityQueryKey = (
+  userId?: string,
+  roleSignature?: string,
+) => ['user-facility', userId, roleSignature ?? 'no-role'] as const;
+
+export const fetchUserFacilityInfo = async ({
+  userId,
+  primaryRole,
+}: {
+  userId: string;
+  primaryRole: UserRole | null;
+}): Promise<UserFacilityInfo> => {
+  console.debug(
+    `[react-query] fetching facility metadata for user ${userId} (role signature: ${buildUserRoleSignature(primaryRole)})`,
+  );
+
+  if (!primaryRole) {
+    return buildPendingOrNoRoleInfo(userId);
+  }
+
+  return buildAssignedRoleInfo(primaryRole);
+};
+
+export const createUserFacilityQueryOptions = (
+  userId?: string,
+  primaryRole?: UserRole | null,
+) => ({
+  queryKey: userFacilityQueryKey(userId, buildUserRoleSignature(primaryRole)),
+  queryFn: async () => {
+    if (!userId) {
+      return defaultFacilityInfo;
+    }
+
+    return fetchUserFacilityInfo({
+      userId,
+      primaryRole: primaryRole ?? null,
+    });
+  },
+  staleTime: 5 * 60 * 1000,
+  gcTime: 30 * 60 * 1000,
+});
 
 export const useUserFacility = (): UserFacilityInfo => {
   const { user } = useAuth();
-  const [facilityInfo, setFacilityInfo] = useState<UserFacilityInfo>({
-    facilityName: null,
-    facilityType: null,
-    role: null,
-    adminLevel: null,
-    locationDisplay: null,
-    loading: true,
-    error: null,
+  const { userRole, loading: roleLoading, error: roleError } = useUserRole();
+
+  const facilityQuery = useQuery<UserFacilityInfo, Error>({
+    ...createUserFacilityQueryOptions(user?.id, userRole),
+    enabled: !!user?.id && !roleLoading && !roleError,
   });
 
-  useEffect(() => {
-    if (!user) {
-      setFacilityInfo(prev => ({ ...prev, loading: false }));
-      return;
-    }
+  const facilityInfo = facilityQuery.data ?? defaultFacilityInfo;
+  const facilityLoading = facilityQuery.isPending || facilityQuery.isFetching;
 
-    const collectLocationParts = (location: LocationSource) => {
-      if (!location) return [];
-
-      const parts: string[] = [];
-
-      if ('woreda_name' in location && location.woreda_name) {
-        parts.push(location.woreda_name);
-      }
-
-      if ('zone_name' in location && location.zone_name) {
-        parts.push(location.zone_name);
-      }
-
-      if ('region_name' in location && location.region_name) {
-        parts.push(location.region_name);
-      }
-
-      if ('zone' in location && location.zone?.zone_name) {
-        parts.push(location.zone.zone_name);
-      }
-
-      if ('zone' in location && location.zone?.region?.region_name) {
-        parts.push(location.zone.region.region_name);
-      }
-
-      if ('region' in location && location.region?.region_name) {
-        parts.push(location.region.region_name);
-      }
-
-      return Array.from(new Set(parts));
-    };
-
-    const fetchFacilityWithHierarchy = async (facilityId: number): Promise<FacilityHierarchy | null> => {
-        const { data, error } = await supabase
-          .from('facility')
-          .select(
-            `
-              facility_name,
-              facility_type,
-              woreda!facility_woreda_id_fkey (
-                woreda_name,
-                zone!woreda_zone_id_fkey (
-                  zone_name,
-                  region!zone_region_id_fkey (
-                    region_name
-                  )
-                )
-              )
-            `
-          )
-          .eq('facility_id', facilityId)
-          .maybeSingle();
-
-      if (error) {
-        throw error;
-      }
-
-      return (data as FacilityHierarchy | null) ?? null;
-    };
-
-    const fetchAdministrativeLocation = async (role: UserRole): Promise<AdministrativeLocation> => {
-      if (role.woreda_id) {
-        const { data, error } = await supabase
-          .from('woreda')
-          .select(
-            `
-              woreda_name,
-              zone!woreda_zone_id_fkey (
-                zone_name,
-                region!zone_region_id_fkey (
-                  region_name
-                )
-              )
-            `
-          )
-          .eq('woreda_id', role.woreda_id)
-          .maybeSingle();
-
-        if (error) throw error;
-        return data;
-      }
-
-      if (role.zone_id) {
-        const { data, error } = await supabase
-          .from('zone')
-          .select(
-            `
-              zone_name,
-              region!zone_region_id_fkey (
-                region_name
-              )
-            `
-          )
-          .eq('zone_id', role.zone_id)
-          .maybeSingle();
-
-        if (error) throw error;
-        return data;
-      }
-
-      if (role.region_id) {
-        const { data, error } = await supabase
-          .from('region')
-          .select('region_name')
-          .eq('region_id', role.region_id)
-          .maybeSingle();
-
-        if (error) throw error;
-        return data;
-      }
-
-      return null;
-    };
-
-    const buildLocationDisplay = ({
-      facility,
-      location,
-      adminLevel,
-      role,
-    }: {
-      facility?: FacilityHierarchy | null;
-      location?: AdministrativeLocation;
-      adminLevel: string | null;
-      role: string | null;
-    }) => {
-      if (facility) {
-        const locationParts = collectLocationParts(facility.woreda);
-        let display = `${facility.facility_name}${facility.facility_type ? ` (${facility.facility_type})` : ''}`;
-        if (locationParts.length) {
-          display += ` – ${locationParts.join(', ')}`;
-        }
-        return display;
-      }
-
-      const locationParts = collectLocationParts(location);
-      if (locationParts.length) {
-        return `${locationParts.join(', ')}${adminLevel ? ` – ${adminLevel} Level` : ''}`;
-      }
-
-      return role ? `${role} Dashboard` : 'National Overview';
-    };
-
-    const buildPendingOrNoRoleInfo = async (): Promise<UserFacilityInfo> => {
-      const [
-        { data: pendingRequestsData, error: pendingError },
-        { data: profileData, error: profileError },
-      ] = await Promise.all([
-        supabase
-          .from('user_role_requests')
-          .select('requested_role, admin_level, status')
-          .eq('user_id', user.id)
-          .eq('status', 'pending')
-          .limit(1),
-        supabase
-          .from('profiles')
-          .select('preferred_facility_id')
-          .eq('user_id', user.id)
-          .maybeSingle(),
-      ]);
-
-      if (pendingError) throw pendingError;
-      if (profileError) throw profileError;
-
-      const pendingRequests = (pendingRequestsData as PendingRequest[] | null) || [];
-      const preferredFacilityId = profileData?.preferred_facility_id as number | null | undefined;
-
-      if (preferredFacilityId) {
-        const facility = await fetchFacilityWithHierarchy(preferredFacilityId);
-        const locationDisplay = facility
-          ? buildLocationDisplay({ facility, adminLevel: pendingRequests[0]?.admin_level ?? null, role: pendingRequests[0]?.requested_role ?? null })
-          : 'Preferred Facility';
-
-        return {
-          facilityName: facility?.facility_name ?? null,
-          facilityType: facility?.facility_type ?? null,
-          role: pendingRequests.length ? 'Pending Approval' : 'No Role Assigned',
-          adminLevel: pendingRequests[0]?.admin_level ?? null,
-          locationDisplay: pendingRequests.length ? `${locationDisplay} – awaiting approval` : locationDisplay,
-          loading: false,
-          error: null,
-        };
-      }
-
-      if (pendingRequests.length > 0) {
-        return {
-          facilityName: null,
-          facilityType: null,
-          role: 'Pending Approval',
-          adminLevel: pendingRequests[0].admin_level,
-          locationDisplay: 'Role request pending approval',
-          loading: false,
-          error: null,
-        };
-      }
-
-      return {
-        facilityName: null,
-        facilityType: null,
-        role: 'No Role Assigned',
-        adminLevel: null,
-        locationDisplay: 'Please contact administrator',
-        loading: false,
-        error: null,
-      };
-    };
-
-    const buildAssignedRoleInfo = async (primaryRole: UserRole): Promise<UserFacilityInfo> => {
-      const facilityPromise: Promise<FacilityHierarchy | null> = primaryRole.facility_id
-        ? fetchFacilityWithHierarchy(primaryRole.facility_id)
-        : Promise.resolve<FacilityHierarchy | null>(null);
-
-      const locationPromise: Promise<AdministrativeLocation> = primaryRole.facility_id
-        ? Promise.resolve<AdministrativeLocation>(null)
-        : fetchAdministrativeLocation(primaryRole);
-
-      const [facility, location] = await Promise.all([facilityPromise, locationPromise]);
-
-      const locationDisplay = buildLocationDisplay({
-        facility,
-        location,
-        adminLevel: primaryRole.admin_level,
-        role: primaryRole.role,
-      });
-
-      return {
-        facilityName: facility?.facility_name ?? null,
-        facilityType: facility?.facility_type ?? null,
-        role: primaryRole.role,
-        adminLevel: primaryRole.admin_level,
-        locationDisplay,
-        loading: false,
-        error: null,
-      };
-    };
-
-    const fetchUserFacilityInfo = async () => {
-      try {
-        setFacilityInfo(prev => ({ ...prev, loading: true, error: null }));
-
-        // First, get user's roles and admin assignments
-        const { data: userRolesData, error: rolesError } = await supabase
-          .from('user_roles')
-          .select('role, admin_level, facility_id, woreda_id, zone_id, region_id')
-          .eq('user_id', user.id);
-
-        if (rolesError) {
-          console.error('Error fetching user roles:', rolesError);
-          throw rolesError;
-        }
-
-        const userRoles = (userRolesData as UserRole[] | null) ?? [];
-
-        if (userRoles.length === 0) {
-          const info = await buildPendingOrNoRoleInfo();
-          setFacilityInfo(info);
-          return;
-        }
-
-        // Get the primary role (first one for now, could be enhanced to prioritize)
-        const primaryRole = userRoles[0];
-        const info = await buildAssignedRoleInfo(primaryRole);
-        setFacilityInfo(info);
-
-      } catch (error: any) {
-        console.error('Error fetching user facility info:', error);
-        setFacilityInfo(prev => ({
-          ...prev,
-          loading: false,
-          error: error.message || 'Failed to load user information',
-        }));
-      }
-    };
-
-    fetchUserFacilityInfo();
-  }, [user]);
-
-  return facilityInfo;
+  return {
+    ...facilityInfo,
+    loading: !!user?.id ? roleLoading || facilityLoading : false,
+    error: roleError ?? facilityQuery.error?.message ?? facilityInfo.error,
+  };
 };
+
+export default useUserFacility;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -13,8 +13,7 @@ import { NationalWorkflow } from "@/components/workflow/NationalWorkflow";
 import UserProfileBadge from "@/components/auth/UserProfileBadge";
 import { TodayQuickStats } from "@/components/inventory/TodayQuickStats";
 import { useAuth } from "@/context/AuthContext";
-import { useUserRole } from "@/hooks/useUserRole";
-import { useUserFacility } from "@/hooks/useUserFacility";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { MapPin, Users, Globe, Building, Settings } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -22,8 +21,7 @@ const Landing: React.FC = () => {
   const location = useLocation();
   const canonical = `${window.location.origin}${location.pathname}`;
   const { user } = useAuth();
-  const { userRole, loading: roleLoading } = useUserRole();
-  const facilityInfo = useUserFacility();
+  const { loading, userRole, facilityRole } = useCurrentUser();
 
   const getRoleDisplay = (role: string | undefined) => {
     switch (role) {
@@ -39,7 +37,7 @@ const Landing: React.FC = () => {
   };
 
   const renderRoleBasedView = () => {
-    switch (userRole?.role) {
+    switch (userRole) {
       case "admin":
         return <NationalWorkflow />;
       case "analyst":
@@ -51,7 +49,7 @@ const Landing: React.FC = () => {
     }
   };
 
-  if (roleLoading || facilityInfo.loading) {
+  if (loading) {
     return (
       <main className="container py-6">
         <div className="flex items-center justify-center min-h-[400px]">
@@ -64,7 +62,7 @@ const Landing: React.FC = () => {
     );
   }
 
-  const roleDisplay = getRoleDisplay(userRole?.role);
+  const roleDisplay = getRoleDisplay(userRole ?? facilityRole ?? undefined);
   const RoleIcon = roleDisplay.icon;
 
   return (
@@ -89,7 +87,7 @@ const Landing: React.FC = () => {
       </div>
 
       {/* Legacy Dashboard Widgets (for admin/analyst overview) */}
-      {(userRole?.role === "admin" || userRole?.role === "analyst") && (
+      {(userRole === "admin" || userRole === "analyst") && (
         <Tabs defaultValue="workflow" className="w-full">
           <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger value="workflow">Workflow Overview</TabsTrigger>
@@ -105,7 +103,7 @@ const Landing: React.FC = () => {
       )}
 
       {/* Show message if user has no role assigned */}
-      {!userRole?.role && !roleLoading && (
+      {!userRole && !loading && (
         <Card className="border-amber-200 bg-amber-50">
           <CardHeader>
             <CardTitle className="text-amber-800">Role Assignment Pending</CardTitle>


### PR DESCRIPTION
## Summary
- migrate `useUserRole` to a react-query powered implementation that caches per-user role data
- add a shared facility metadata query so the facility hierarchy chain executes once and expose helper query utilities
- rework `useCurrentUser` to consume the cached queries directly and rely on the shared role/facility data

## Testing
- npm run lint *(fails: existing lint violations unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68da8c1b5b24832e9b4ac8ab9cc9aa56